### PR TITLE
ci: Keep 50 package versions.

### DIFF
--- a/.github/workflows/remove-old-package-versions.yml
+++ b/.github/workflows/remove-old-package-versions.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           package-name: mtail
           package-type: container
-          min-versions-to-keep: 10
+          min-versions-to-keep: 50


### PR DESCRIPTION
If we build once a week then this gives about a year of pinning before people
have to upgrade.  Personally I think 90 days should be the limit but I can't be
too prescriptive.

Fixes: #121