### PR TITLE
ci: Add a new workflow to auto-approve dependencies.

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -1,0 +1,27 @@
+# We "trust" dependabot and renovate updates once they pass tests.
+# (this still requires all other checks to pass!)
+
+# This doesn't work on forked repos per the discussion in
+# https://github.com/pascalgn/automerge-action/issues/46 so don't attempt to
+# add people other than dependabot to the if field below.
+name: auto-approve
+on:
+  workflow_run:
+    workflows:
+      - ci
+    types:
+      - completed
+
+jobs:
+  enable-automerge-and-approve:
+    if: github.event.workflow_run.conclusion == 'success' && ((github.event.workflow_run.pull_requests[0].user.login == 'dependabot[bot]' && contains(github.event.workflow_run.pull_requests[0].labels.*.name, 'dependencies')) || (github.event.workflow_run.pull_requests[0].user.login == 'renovate[bot]' && contains(github.event.workflow_run.pull_requests[0].labels.*.name, 'renovate'))) 
+    runs-on: ubuntu-latest
+    # https://github.com/orgs/community/discussions/24686
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - run: gh pr merge ${{ github.event.workflow_run.pull_requests[0].number }} --auto
+      - run: gh pr review ${{ github.event.workflow_run.pull_requests[0].number }} --approve


### PR DESCRIPTION
This uses workflow_run as the trigger and checks both renovate and dependabot.