### PR TITLE
fix: Repair two memory leaks in the VM.

### DIFF
--- a/internal/runtime/vm/vm.go
+++ b/internal/runtime/vm/vm.go
@@ -748,7 +748,7 @@ func (v *VM) execute(t *thread, i code.Instr) {
 				return
 			}
 			// fmt.Printf("s: %v\n", s)
-			keys[a] = s
+			keys[a] = strings.Clone(s)
 			// fmt.Printf("Keys: %v\n", keys)
 		}
 		// fmt.Printf("Keys: %v\n", keys)

--- a/internal/runtime/vm/vm.go
+++ b/internal/runtime/vm/vm.go
@@ -964,6 +964,10 @@ func (v *VM) ProcessLogLine(_ context.Context, line *logline.LogLine) {
 	defer func() {
 		LineProcessingDurations.WithLabelValues(v.name).Observe(time.Since(start).Seconds())
 	}()
+	defer func() {
+		v.input = nil
+		v.t = nil
+	}()
 	t := new(thread)
 	t.matched = false
 	v.t = t

--- a/internal/runtime/vm/vm.go
+++ b/internal/runtime/vm/vm.go
@@ -968,24 +968,22 @@ func (v *VM) ProcessLogLine(_ context.Context, line *logline.LogLine) {
 		v.input = nil
 		v.t = nil
 	}()
-	t := new(thread)
-	t.matched = false
-	v.t = t
+	v.t = new(thread)
+	v.t.matched = false
 	v.input = line
-	t.stack = make([]interface{}, 0)
-	t.matches = make(map[int][]string, len(v.re))
+	v.t.stack = make([]interface{}, 0)
+	v.t.matches = make(map[int][]string, len(v.re))
 	for {
-		if t.pc >= len(v.prog) {
+		if v.t.pc >= len(v.prog) {
 			return
 		}
 		if v.trace != nil {
-			v.trace = append(v.trace, t.pc)
+			v.trace = append(v.trace, v.t.pc)
 		}
-		i := v.prog[t.pc]
-		t.pc++
-		v.execute(t, i)
+		i := v.prog[v.t.pc]
+		v.t.pc++
+		v.execute(v.t, i)
 		if v.terminate {
-			// Terminate only stops this invocation on this line of input; reset the terminate flag.
 			v.terminate = false
 			return
 		}

--- a/internal/runtime/vm/vm_test.go
+++ b/internal/runtime/vm/vm_test.go
@@ -6,8 +6,11 @@ package vm
 import (
 	"context"
 	"regexp"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/jaqx0r/mtail/internal/logline"
 	"github.com/jaqx0r/mtail/internal/metrics"
@@ -925,6 +928,60 @@ func TestTimestampInstr(t *testing.T) {
 	tos = time.Unix(v.t.Pop().(int64), 0).UTC()
 	if tos != newT {
 		t.Errorf("Expecting timestamp to be %s, was %s", newT, tos)
+	}
+}
+
+func TestProcessLogLineDoesNotPinLargeCaptureGroup(t *testing.T) {
+	// Build a program that matches a regex, captures a substring, and stores it
+	// as a metric label key via Dload.  The stored key must not pin the original
+	// log line's backing array.
+	re := regexp.MustCompile(`.(KEY).`)
+
+	m := []*metrics.Metric{
+		metrics.NewMetric("m", "tst", metrics.Counter, metrics.Int, "label"),
+	}
+	prog := []code.Instr{
+		{code.Match, 0, 0},
+		{code.Push, 0, 0},
+		{code.Capref, 1, 0},
+		{code.Mload, 0, 0},
+		{code.Dload, 1, 0},
+	}
+	obj := &code.Object{
+		Metrics: m,
+		Program: prog,
+		Regexps: []*regexp.Regexp{re},
+	}
+	v := New("leaktest", obj, true, nil, false, false)
+
+	// Allocate a large log line (~200KB).  The regex `.(KEY).` matches
+	// "aKEYb" and captures "KEY".  Save the data pointer of the capture to
+	// compare against the stored label value later.
+	const offset = 100000
+	large := strings.Repeat("x", offset) + "aKEYb" + strings.Repeat("y", 100000)
+	capture := large[offset+1 : offset+4] // "KEY" — shares backing with large
+	origPtr := unsafe.StringData(capture)
+
+	v.ProcessLogLine(context.Background(), logline.New(context.Background(), "test", 0, large))
+	runtime.KeepAlive(large) // ensure large survives until ProcessLogLine completes
+
+	// Retrieve the stored label value.
+	lv := m[0].FindLabelValueOrNil([]string{"KEY"})
+	if lv == nil {
+		t.Fatal("label value not found")
+	}
+	stored := lv.Labels[0]
+
+	// Drop all references to the large backing array.  If strings.Clone was not
+	// used, the stored key still pins the original backing array via the shared
+	// data pointer.
+	large = ""
+	runtime.GC()
+
+	// If the stored key shares the original backing array, its data pointer
+	// matches.  If strings.Clone allocated a fresh copy, they differ.
+	if unsafe.StringData(stored) == origPtr {
+		t.Error("stored label key shares backing array with original log line; Dload should use strings.Clone to detach it")
 	}
 }
 

--- a/internal/runtime/vm/vm_test.go
+++ b/internal/runtime/vm/vm_test.go
@@ -927,3 +927,17 @@ func TestTimestampInstr(t *testing.T) {
 		t.Errorf("Expecting timestamp to be %s, was %s", newT, tos)
 	}
 }
+
+func TestProcessLogLineClearsInput(t *testing.T) {
+	obj := &code.Object{Program: []code.Instr{}} // empty program returns immediately
+	v := New("leaktest", obj, true, nil, false, false)
+	line := logline.New(context.Background(), "test", 0, "hello world")
+
+	v.ProcessLogLine(context.Background(), line)
+	if v.input != nil {
+		t.Error("v.input was not cleared after ProcessLogLine returned")
+	}
+	if v.t != nil {
+		t.Error("v.t was not cleared after ProcessLogLine returned")
+	}
+}


### PR DESCRIPTION
Make sure the input line and the thread are released at the end of ProcessLogLine so that the memory is not pinned until the next log line appears for that programme.

Make a copy of metric label keys so that the stored label values in the Metric Store do not share the original log line's backing array.  Any capture group reference would cause the entire line to be live for the lifetime of the process, before this.

Issue: #390