### PR TITLE
fix: Use the default SystemCallFilter setting for systemd hardening.

### DIFF
--- a/mtail.service
+++ b/mtail.service
@@ -19,7 +19,6 @@ AmbientCapabilities=
 CapabilityBoundingSet=
 KeyringMode=private
 LockPersonality=yes
-LockPersonality=yes
 MemoryDenyWriteExecute=yes
 MountFlags=private
 NoNewPrivileges=yes
@@ -40,7 +39,7 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 SystemCallArchitectures=native
-SystemCallFilter=@basic-io @file-system @io-event @ipc @network-io @signal clone kill madvise setrlimit tgkill uname
+SystemCallFilter=@default
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The custom list is underspecified, and causes `mtail` to crash before
`main`. This change allows all the normal Go runtime system calls to
execute.

Also remove duplicate LockPersonality option.

Fixes: #175