### PR TITLE
refactor: Store the indices of the capture groups instead of strings.

### DIFF
--- a/internal/runtime/vm/vm.go
+++ b/internal/runtime/vm/vm.go
@@ -41,12 +41,24 @@ var (
 	}, []string{"prog"})
 )
 
+type matchResult struct {
+	text    string
+	indices []int
+}
+
+func (m matchResult) captureGroup(n int) string {
+	if m.indices[2*n] == -1 {
+		return ""
+	}
+	return m.text[m.indices[2*n]:m.indices[2*n+1]]
+}
+
 type thread struct {
-	pc      int              // Program counter.
-	matched bool             // Flag set if any match has been found.
-	matches map[int][]string // Match result variables.
-	time    time.Time        // Time register.
-	stack   []interface{}    // Data stack.
+	pc      int                 // Program counter.
+	matched bool                // Flag set if any match has been found.
+	matches map[int]matchResult // Match result variables, accessed as text[indices[n]:indices[n+1]].
+	time    time.Time           // Time register.
+	stack   []interface{}       // Data stack.
 }
 
 // VM describes the virtual machine for each program.  It contains virtual
@@ -360,8 +372,11 @@ func (v *VM) execute(t *thread, i code.Instr) {
 		// Store the results in the operandth element of the stack,
 		// where i.opnd == the matched re index
 		index := i.Operand.(int)
-		t.matches[index] = v.re[index].FindStringSubmatch(v.input.Line)
-		t.Push(t.matches[index] != nil)
+		t.matches[index] = matchResult{
+			text:    v.input.Line,
+			indices: v.re[index].FindStringSubmatchIndex(v.input.Line),
+		}
+		t.Push(t.matches[index].indices != nil)
 
 	case code.Smatch:
 		// match regex against item on the stack
@@ -371,8 +386,11 @@ func (v *VM) execute(t *thread, i code.Instr) {
 			v.errorf("+%v", err)
 			return
 		}
-		t.matches[index] = v.re[index].FindStringSubmatch(line)
-		t.Push(t.matches[index] != nil)
+		t.matches[index] = matchResult{
+			text:    line,
+			indices: v.re[index].FindStringSubmatchIndex(line),
+		}
+		t.Push(t.matches[index].indices != nil)
 
 	case code.Cmp:
 		// Compare two elements on the stack.
@@ -580,7 +598,8 @@ func (v *VM) execute(t *thread, i code.Instr) {
 			}
 			re := int(val)
 			// Store the result from the re'th index at the s'th index
-			ts = t.matches[re][s]
+			m := t.matches[re]
+			ts = m.captureGroup(s)
 		}
 		if cached, ok := v.timeMemos.Get(ts); !ok {
 			tm := v.ParseTime(layout, ts)
@@ -624,11 +643,16 @@ func (v *VM) execute(t *thread, i code.Instr) {
 			v.errorf("Invalid operand %v, not an int", i.Operand)
 			return
 		}
-		if len(t.matches[re]) <= op {
-			v.errorf("Not enough capture groups matched from %v to select %dth", t.matches[re], op)
+		m, ok := t.matches[re]
+		if !ok {
+			v.errorf("No match result for regex index %d", re)
 			return
 		}
-		t.Push(t.matches[re][op])
+		if len(m.indices) < 2*(op+1) {
+			v.errorf("Not enough capture groups matched from %d indices to select %dth", len(m.indices)/2, op)
+			return
+		}
+		t.Push(m.captureGroup(op))
 
 	case code.Str:
 		// Put a string constant onto the stack
@@ -1015,7 +1039,7 @@ func New(name string, obj *code.Object, syslogUseCurrentYear bool, loc *time.Loc
 		threadPool: sync.Pool{
 			New: func() any {
 				return &thread{
-					matches: make(map[int][]string, len(obj.Regexps)),
+					matches: make(map[int]matchResult, len(obj.Regexps)),
 					stack:   make([]interface{}, 0),
 				}
 			},

--- a/internal/runtime/vm/vm_test.go
+++ b/internal/runtime/vm/vm_test.go
@@ -36,7 +36,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{},
 		[]interface{}{true},
-		thread{pc: 0, matches: map[int][]string{0: {"aaaab"}}},
+		thread{pc: 0, matches: map[int]matchResult{0: {text: "aaaab", indices: []int{0, 5}}}},
 	},
 	{
 		"cmp lt",
@@ -45,7 +45,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1, "2"},
 		[]interface{}{true},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp eq",
@@ -54,7 +54,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"2", "2"},
 		[]interface{}{true},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp gt",
@@ -63,7 +63,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 1},
 		[]interface{}{true},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp le",
@@ -72,7 +72,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, "2"},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp ne",
@@ -81,7 +81,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"1", "2"},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp ge",
@@ -90,7 +90,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 2},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp gt float float",
@@ -99,7 +99,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"2.0", "1.0"},
 		[]interface{}{true},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp gt float int",
@@ -108,7 +108,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"1.0", "2"},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp gt int float",
@@ -117,7 +117,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"1", "2.0"},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp eq string string false",
@@ -126,7 +126,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"abc", "def"},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp eq string string true",
@@ -135,7 +135,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"abc", "abc"},
 		[]interface{}{true},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp gt float float",
@@ -144,7 +144,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2.0, 1.0},
 		[]interface{}{true},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp gt float int",
@@ -153,7 +153,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1.0, 2},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cmp gt int float",
@@ -162,7 +162,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1, 2.0},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"jnm",
@@ -171,7 +171,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{false},
 		[]interface{}{},
-		thread{pc: 37, matches: map[int][]string{}},
+		thread{pc: 37, matches: map[int]matchResult{}},
 	},
 	{
 		"jm",
@@ -180,7 +180,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{false},
 		[]interface{}{},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"jmp",
@@ -189,7 +189,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{},
 		[]interface{}{},
-		thread{pc: 37, matches: map[int][]string{}},
+		thread{pc: 37, matches: map[int]matchResult{}},
 	},
 	{
 		"strptime",
@@ -200,7 +200,7 @@ var instructions = []struct {
 		[]interface{}{},
 		thread{
 			pc: 0, time: time.Date(2012, 1, 18, 6, 25, 0, 0, time.UTC),
-			matches: map[int][]string{},
+			matches: map[int]matchResult{},
 		},
 	},
 	{
@@ -210,7 +210,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 1},
 		[]interface{}{int64(3)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"isub",
@@ -219,7 +219,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 1},
 		[]interface{}{int64(1)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"imul",
@@ -228,7 +228,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 1},
 		[]interface{}{int64(2)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"idiv",
@@ -237,7 +237,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{4, 2},
 		[]interface{}{int64(2)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"imod",
@@ -246,7 +246,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{4, 2},
 		[]interface{}{int64(0)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"imod 2",
@@ -255,7 +255,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{3, 2},
 		[]interface{}{int64(1)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"tolower",
@@ -264,7 +264,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"mIxeDCasE"},
 		[]interface{}{"mixedcase"},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"length",
@@ -273,7 +273,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"1234"},
 		[]interface{}{4},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"length 0",
@@ -282,7 +282,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{""},
 		[]interface{}{0},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"shl",
@@ -291,7 +291,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 1},
 		[]interface{}{int64(4)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"shr",
@@ -300,7 +300,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 1},
 		[]interface{}{int64(1)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"and",
@@ -309,7 +309,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 1},
 		[]interface{}{int64(0)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"or",
@@ -318,7 +318,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 1},
 		[]interface{}{int64(3)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"xor",
@@ -327,7 +327,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 1},
 		[]interface{}{int64(3)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"xor 2",
@@ -336,7 +336,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 3},
 		[]interface{}{int64(1)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"xor 3",
@@ -345,7 +345,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{-1, 3},
 		[]interface{}{int64(^3)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"neg",
@@ -354,7 +354,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{0},
 		[]interface{}{int64(-1)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"not",
@@ -363,7 +363,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{false},
 		[]interface{}{true},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"pow",
@@ -372,7 +372,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2, 2},
 		[]interface{}{int64(4)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"s2i pop",
@@ -381,7 +381,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"ff", 16},
 		[]interface{}{int64(255)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"s2i",
@@ -390,7 +390,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"190"},
 		[]interface{}{int64(190)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"s2f",
@@ -399,7 +399,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"1.0"},
 		[]interface{}{float64(1.0)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"i2f",
@@ -408,7 +408,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1},
 		[]interface{}{float64(1.0)},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"settime",
@@ -417,7 +417,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{int64(0)},
 		[]interface{}{},
-		thread{pc: 0, time: time.Unix(0, 0).UTC(), matches: map[int][]string{}},
+		thread{pc: 0, time: time.Unix(0, 0).UTC(), matches: map[int]matchResult{}},
 	},
 	{
 		"push int",
@@ -426,7 +426,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{},
 		[]interface{}{1},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"push float",
@@ -435,7 +435,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{},
 		[]interface{}{1.0},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"setmatched false",
@@ -444,7 +444,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{},
 		[]interface{}{},
-		thread{matched: false, pc: 0, matches: map[int][]string{}},
+		thread{matched: false, pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"setmatched true",
@@ -453,7 +453,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{},
 		[]interface{}{},
-		thread{matched: true, pc: 0, matches: map[int][]string{}},
+		thread{matched: true, pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"otherwise",
@@ -462,7 +462,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{},
 		[]interface{}{true},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"fadd",
@@ -471,7 +471,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1.0, 2.0},
 		[]interface{}{3.0},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"fsub",
@@ -480,7 +480,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1.0, 2.0},
 		[]interface{}{-1.0},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"fmul",
@@ -489,7 +489,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1.0, 2.0},
 		[]interface{}{2.0},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"fdiv",
@@ -498,7 +498,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1.0, 2.0},
 		[]interface{}{0.5},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"fmod",
@@ -507,7 +507,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1.0, 2.0},
 		[]interface{}{1.0},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"fpow",
@@ -516,7 +516,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{2.0, 2.0},
 		[]interface{}{4.0},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"getfilename",
@@ -525,7 +525,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{},
 		[]interface{}{testFilename},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"i2s",
@@ -534,7 +534,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1},
 		[]interface{}{"1"},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"f2s",
@@ -543,7 +543,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{3.1},
 		[]interface{}{"3.1"},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"cat",
@@ -552,7 +552,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"first", "second"},
 		[]interface{}{"firstsecond"},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"icmp gt false",
@@ -561,7 +561,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1, 2},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"fcmp gt false",
@@ -570,7 +570,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{1.0, 2.0},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"scmp eq false",
@@ -579,7 +579,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"abc", "def"},
 		[]interface{}{false},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 	{
 		"subst",
@@ -588,7 +588,7 @@ var instructions = []struct {
 		[]string{},
 		[]interface{}{"aa" /*old*/, "a" /*new*/, "caat"},
 		[]interface{}{"cat"},
-		thread{pc: 0, matches: map[int][]string{}},
+		thread{pc: 0, matches: map[int]matchResult{}},
 	},
 }
 
@@ -612,7 +612,7 @@ func TestInstrs(t *testing.T) {
 			for _, item := range tc.reversedStack {
 				v.t.Push(item)
 			}
-			v.t.matches = make(map[int][]string)
+			v.t.matches = make(map[int]matchResult)
 			v.input = logline.New(context.Background(), testFilename, logline.GetHash(testFilename), "aaaab")
 			v.execute(v.t, tc.i)
 			if v.terminate {
@@ -623,7 +623,7 @@ func TestInstrs(t *testing.T) {
 
 			tc.expectedThread.stack = tc.expectedStack
 
-			testutil.ExpectNoDiff(t, &tc.expectedThread, v.t, testutil.AllowUnexported(thread{}))
+			testutil.ExpectNoDiff(t, &tc.expectedThread, v.t, testutil.AllowUnexported(thread{}), testutil.AllowUnexported(matchResult{}))
 		})
 	}
 }
@@ -634,7 +634,7 @@ func makeVM(i code.Instr, m []*metrics.Metric) *VM {
 	v := New("test", obj, true, nil, false, false)
 	v.t = new(thread)
 	v.t.stack = make([]interface{}, 0)
-	v.t.matches = make(map[int][]string)
+	v.t.matches = make(map[int]matchResult)
 	v.input = logline.New(context.Background(), testFilename, logline.GetHash(testFilename), "aaaab")
 	return v
 }


### PR DESCRIPTION
This avoids about 2MB of result allocations per regexp match.

`regexp.FindStringSubmatch` returns `[]string` — a new slice **plus N+1 new string allocations** (one for the full match, one per capture group). Each string copies its data from the original log line onto the heap. On a typical dhcpd log line with 7 capture groups, that's 8 separate heap-allocated strings per match.

`regexp.FindStringSubmatchIndex` returns `[]int` — a single flat slice of byte-position pairs. No string data is copied. The original text is kept alive by a `matchResult.text` reference, and capture groups are read on demand via `text[indices[2*n]:indices[2*n+1]]`, which creates only a lightweight string header (no data copy).

An alternation like `(group_a|group_b)` produces index pair `{-1, -1}` for the unmatched branch. With the old `FindStringSubmatch` this came back as `""` (a valid empty string). The index-based code would panic on a negative slice bound, so the new `captureGroup` method checks for `-1` and returns `""` explicitly.

Issue: #390