### PR TITLE
test: Fix a race in testing logstream cancellation.

### DIFF
--- a/internal/tailer/logstream/dgramstream_unix_test.go
+++ b/internal/tailer/logstream/dgramstream_unix_test.go
@@ -98,24 +98,21 @@ func TestDgramStreamReadCompletedBecauseCancel(t *testing.T) {
 			ds, err := logstream.New(ctx, &wg, waker, sockName, logstream.OneShotDisabled)
 			testutil.FatalIfErr(t, err)
 
-			expected := []*logline.LogLine{
-				{Context: context.TODO(), Filename: sockName, Line: "1", Filenamehash: logline.GetHash(sockName)},
-			}
-			checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, ds.Lines())
-
 			s, err := net.Dial(scheme, addr)
 			testutil.FatalIfErr(t, err)
 
 			_, err = s.Write([]byte("1\n"))
 			testutil.FatalIfErr(t, err)
 
-			// Yield to give the stream a chance to read.
-			time.Sleep(10 * time.Millisecond)
+			// Read from Lines to synchronise with the stream goroutine: this
+			// blocks until the stream has consumed the data, proving it read
+			// "1\n" from the socket before we cancel.
+			expected := &logline.LogLine{Context: context.TODO(), Filename: sockName, Line: "1", Filenamehash: logline.GetHash(sockName)}
+			received := <-ds.Lines()
+			testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
 			cancel() // This cancellation should cause the stream to shut down.
 			wg.Wait()
-
-			checkLineDiff()
 
 			if v := <-ds.Lines(); v != nil {
 				t.Errorf("expecting dgramstream to be complete because cancel")

--- a/internal/tailer/logstream/fifostream_unix_test.go
+++ b/internal/tailer/logstream/fifostream_unix_test.go
@@ -80,17 +80,18 @@ func TestFifoStreamReadCompletedBecauseCancel(t *testing.T) {
 
 		ps, err := logstream.New(ctx, &wg, waker, name, logstream.OneShotDisabled)
 		testutil.FatalIfErr(t, err)
-		expected := []*logline.LogLine{
-			{Context: context.TODO(), Filename: name, Line: "1", Filenamehash: logline.GetHash(name)},
-		}
-		checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, ps.Lines())
 
 		testutil.WriteString(t, f, "1\n")
 
+		// Read from Lines to synchronise with the stream goroutine: this
+		// blocks until the stream has consumed the data, proving it read "1\n"
+		// from the fifo before we cancel.
+		expected := &logline.LogLine{Context: context.TODO(), Filename: name, Line: "1", Filenamehash: logline.GetHash(name)}
+		received := <-ps.Lines()
+		testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
+
 		cancel() // Cancellation here should cause the stream to shut down.
 		wg.Wait()
-
-		checkLineDiff()
 
 		if v := <-ps.Lines(); v != nil {
 			t.Errorf("expecting pipestream to be complete because cancelled")

--- a/internal/tailer/logstream/socketstream_unix_test.go
+++ b/internal/tailer/logstream/socketstream_unix_test.go
@@ -95,24 +95,21 @@ func TestSocketStreamReadCompletedBecauseCancel(t *testing.T) {
 			ss, err := logstream.New(ctx, &wg, waker, sockName, logstream.OneShotDisabled)
 			testutil.FatalIfErr(t, err)
 
-			expected := []*logline.LogLine{
-				{Context: context.TODO(), Filename: sockName, Line: "1", Filenamehash: logline.GetHash(sockName)},
-			}
-			checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, ss.Lines())
-
 			s, err := net.Dial(scheme, addr)
 			testutil.FatalIfErr(t, err)
 
 			_, err = s.Write([]byte("1\n"))
 			testutil.FatalIfErr(t, err)
 
-			// Yield to give the stream a chance to read.
-			time.Sleep(10 * time.Millisecond)
+			// Read from Lines to synchronise with the stream goroutine: this
+			// blocks until the stream has consumed the data, proving it read
+			// "1\n" from the socket before we cancel.
+			expected := &logline.LogLine{Context: context.TODO(), Filename: sockName, Line: "1", Filenamehash: logline.GetHash(sockName)}
+			received := <-ss.Lines()
+			testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
-			cancel() // This cancellation should cause the stream to shut down immediately.
+			cancel() // This cancellation should cause the stream to shut down.
 			wg.Wait()
-
-			checkLineDiff()
 
 			if v := <-ss.Lines(); v != nil {
 				t.Errorf("expecting socketstream to be complete because cancel")


### PR DESCRIPTION
The asynchronous drain goroutine `ExpectLinesReceivedNoDiff` provides no
synchronisation point between the data write, and `cancel()`.

Cancellation tests should always use a synchronous read from the lines channel.