### PR TITLE
filestream: allow deletion of open files on Windows

### DIFF
--- a/internal/tailer/logstream/BUILD.bazel
+++ b/internal/tailer/logstream/BUILD.bazel
@@ -8,6 +8,8 @@ go_library(
         "dgramstream.go",
         "fifostream.go",
         "filestream.go",
+        "filestream_open_unix.go",
+        "filestream_open_windows.go",
         "logstream.go",
         "reader.go",
         "socketstream.go",

--- a/internal/tailer/logstream/filestream.go
+++ b/internal/tailer/logstream/filestream.go
@@ -59,7 +59,7 @@ func newFileStream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, p
 }
 
 func (fs *fileStream) stream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, fi os.FileInfo, oneShot OneShotMode, streamFromStart bool) error {
-	fd, err := os.OpenFile(fs.pathname, os.O_RDONLY, 0o600)
+	fd, err := openFile(fs.pathname)
 	if err != nil {
 		logErrors.Add(fs.sourcename, 1)
 		return err

--- a/internal/tailer/logstream/filestream_open_unix.go
+++ b/internal/tailer/logstream/filestream_open_unix.go
@@ -1,0 +1,14 @@
+// Copyright 2026 The mtail Authors. All Rights Reserved.
+// This file is available under the Apache license.
+
+//go:build !windows
+
+package logstream
+
+import (
+	"os"
+)
+
+func openFile(pathname string) (*os.File, error) {
+	return os.OpenFile(pathname, os.O_RDONLY, 0o600)
+}

--- a/internal/tailer/logstream/filestream_open_windows.go
+++ b/internal/tailer/logstream/filestream_open_windows.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The mtail Authors. All Rights Reserved.
+// This file is available under the Apache license.
+
+//go:build windows
+
+package logstream
+
+import (
+	"os"
+	"syscall"
+)
+
+func openFile(pathname string) (*os.File, error) {
+	pathp, err := syscall.UTF16PtrFromString(pathname)
+	if err != nil {
+		return nil, &os.PathError{Op: "utf16", Path: pathname, Err: err}
+	}
+	handle, err := syscall.CreateFile(
+		pathp,
+		syscall.GENERIC_READ,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE|syscall.FILE_SHARE_DELETE,
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: pathname, Err: err}
+	}
+	return os.NewFile(uintptr(handle), pathname), nil
+}

--- a/internal/tailer/logstream/filestream_unix_test.go
+++ b/internal/tailer/logstream/filestream_unix_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/jaqx0r/mtail/internal/waker"
 )
 
-// TestFileStreamRotation is a unix-specific test because on Windows, files cannot be removed
-// or renamed while there is an open read handle on them. Instead, log rotation would
-// have to be implemented by copying and then truncating the original file. That test
-// case is already covered by TestFileStreamTruncation.
+// TestFileStreamRotation is a unix-specific test because rotation on Windows uses
+// FILE_SHARE_DELETE to allow rename while the file is open. The test currently
+// exercises the Unix path; Windows rotation via CopyFile+Delete is covered by
+// TestFileStreamTruncation.
 func TestFileStreamRotation(t *testing.T) {
 	var wg sync.WaitGroup
 


### PR DESCRIPTION
Open log files with `FILE_SHARE_DELETE` on Windows so that the OS can delete or rename them while mtail holds a read handle, matching POSIX semantics.

The default `os.OpenFile` on Windows calls `CreateFile` with share flags `FILE_SHARE_READ|FILE_SHARE_WRITE` but not `FILE_SHARE_DELETE`, preventing log rotation while mtail is tailing.

This adds a platform-abstracted `openFile` helper:
- **Windows**: uses `syscall.CreateFile` with `FILE_SHARE_DELETE`
- **Others**: delegates to `os.OpenFile` (unchanged behavior)

Fixes: google/mtail#897, google/mtail#531