### PR TITLE
fix: apply `limit` eviction to hidden metrics (#837)

### DIFF
--- a/internal/exporter/export.go
+++ b/internal/exporter/export.go
@@ -25,7 +25,7 @@ import (
 
 // Commandline Flags.
 var (
-	writeDeadline = flag.Duration("metric_push_write_deadline", 10*time.Second, "Time to wait for a push to succeed before exiting with an error.")
+	writeDeadline       = flag.Duration("metric_push_write_deadline", 10*time.Second, "Time to wait for a push to succeed before exiting with an error.")
 	enableOpenTelemetry = flag.Bool("experimental_enable_opentelemetry", false, "Enable the experimental Open Telemetry metric pusher.")
 )
 
@@ -37,7 +37,7 @@ type Exporter struct {
 	store          *metrics.Store
 	pushInterval   time.Duration
 	hostname       string
-	version string
+	version        string
 	omitProgLabel  bool
 	emitTimestamp  bool
 	exportDisabled bool
@@ -59,7 +59,7 @@ func Hostname(hostname string) Option {
 
 // Version specifies the mtail version to use in exported metrics.
 func Version(version string) Option {
-	return func (e *Exporter) error {
+	return func(e *Exporter) error {
 		e.version = version
 		return nil
 	}
@@ -199,6 +199,9 @@ type formatter func(string, *metrics.Metric, *metrics.LabelSet, time.Duration) s
 
 func (e *Exporter) writeSocketMetrics(c io.Writer, f formatter, exportTotal *expvar.Int, exportSuccess *expvar.Int) error {
 	return e.store.Range(func(m *metrics.Metric) error {
+		if m.Hidden {
+			return nil
+		}
 		m.RLock()
 		// Don't try to send text metrics to any push service.
 		if m.Kind == metrics.Text {

--- a/internal/exporter/graphite.go
+++ b/internal/exporter/graphite.go
@@ -35,6 +35,9 @@ func (e *Exporter) HandleGraphite(w http.ResponseWriter, r *http.Request) {
 			return r.Context().Err()
 		default:
 		}
+		if m.Hidden {
+			return nil
+		}
 		m.RLock()
 		graphiteExportTotal.Add(1)
 		lc := make(chan *metrics.LabelSet)

--- a/internal/exporter/otel.go
+++ b/internal/exporter/otel.go
@@ -29,6 +29,9 @@ func (e *Exporter) Produce(context.Context) ([]metricdata.ScopeMetrics, error) {
 	scopedOtelMetrics := make(map[string][]metricdata.Metrics)
 
 	e.store.Range(func(m *metrics.Metric) error {
+		if m.Hidden {
+			return nil
+		}
 		m.RLock()
 		defer m.RUnlock()
 

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -34,6 +34,9 @@ func (e *Exporter) Collect(c chan<- prometheus.Metric) {
 
 	/* #nosec G104 always retursn nil */
 	e.store.Range(func(m *metrics.Metric) error {
+		if m.Hidden {
+			return nil
+		}
 		m.RLock()
 		// We don't have a way of converting text metrics to prometheus format.
 		if m.Kind == metrics.Text {

--- a/internal/exporter/varz.go
+++ b/internal/exporter/varz.go
@@ -27,6 +27,9 @@ func (e *Exporter) HandleVarz(w http.ResponseWriter, r *http.Request) {
 			return r.Context().Err()
 		default:
 		}
+		if m.Hidden {
+			return nil
+		}
 		m.RLock()
 		exportVarzTotal.Add(1)
 		lc := make(chan *metrics.LabelSet)

--- a/internal/metrics/store_test.go
+++ b/internal/metrics/store_test.go
@@ -13,6 +13,33 @@ import (
 	"github.com/jaqx0r/mtail/internal/testutil"
 )
 
+func TestLimitWithHidden(t *testing.T) {
+	s := NewStore()
+	m := NewMetric("hidden_metric", "prog", Counter, Int, "foo")
+	m.Hidden = true
+	m.Limit = 1
+	testutil.FatalIfErr(t, s.Add(m))
+
+	_, err := m.GetDatum("a")
+	testutil.FatalIfErr(t, err)
+	testutil.FatalIfErr(t, s.Gc())
+
+	_, err = m.GetDatum("b")
+	testutil.FatalIfErr(t, err)
+	testutil.FatalIfErr(t, s.Gc())
+
+	_, err = m.GetDatum("c")
+	testutil.FatalIfErr(t, err)
+	testutil.FatalIfErr(t, s.Gc())
+
+	if len(m.LabelValues) > 2 {
+		t.Errorf("Expected 2 labelvalues got %#v", m.LabelValues)
+	}
+	if x := m.FindLabelValueOrNil([]string{"a"}); x != nil {
+		t.Errorf("found label a which is unexpected: %#v", x)
+	}
+}
+
 func TestMatchingKind(t *testing.T) {
 	s := NewStore()
 	m1 := NewMetric("foo", "prog", Counter, Int)

--- a/internal/mtail/examples_integration_test.go
+++ b/internal/mtail/examples_integration_test.go
@@ -116,6 +116,9 @@ func TestExamplePrograms(t *testing.T) {
 
 				var storeList metrics.MetricSlice
 				store.Range(func(m *metrics.Metric) error {
+					if m.Hidden {
+						return nil
+					}
 					storeList = append(storeList, m)
 					return nil
 				})

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -183,14 +183,12 @@ func (r *Runtime) CompileAndRun(name string, input io.Reader) error {
 
 	// Load the metrics from the compilation into the global metric storage for export.
 	for _, m := range v.Metrics {
-		if !m.Hidden {
-			if r.omitMetricSource {
-				m.Source = ""
-			}
-			err := r.ms.Add(m)
-			if err != nil {
-				return err
-			}
+		if r.omitMetricSource {
+			m.Source = ""
+		}
+		err := r.ms.Add(m)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/internal/runtime/runtime_integration_test.go
+++ b/internal/runtime/runtime_integration_test.go
@@ -1104,6 +1104,9 @@ func TestRuntimeEndToEnd(t *testing.T) {
 
 			var ms metrics.MetricSlice
 			store.Range(func(m *metrics.Metric) error {
+				if m.Hidden {
+					return nil
+				}
 				ms = append(ms, m)
 				return nil
 			})


### PR DESCRIPTION
Hidden metrics were excluded from the global metric Store at load time (internal/runtime/runtime.go:186), so Store.Gc() never iterated them and the `limit` keyword had no effect on hidden metrics.

**Fix:** Remove the `if !m.Hidden` guard so hidden metrics enter the Store and participate in GC. Add `if m.Hidden { return nil }` checks to all 5 exporters to keep them invisible to external consumers. Add `TestLimitWithHidden` reproducing test.

Closes issues #837 and #763.