### PR TITLE
fix: close filestream lines channel when rotation reopen fails (#725)

### DIFF
--- a/internal/tailer/logstream/filestream.go
+++ b/internal/tailer/logstream/filestream.go
@@ -121,6 +121,7 @@ func (fs *fileStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 					// streamFromStart always true on a stream reopen
 					if nerr := fs.stream(ctx, wg, waker, fi, oneShot, true); nerr != nil {
 						glog.Infof("stream(%s): new stream: %v", fs.sourcename, nerr)
+						close(fs.lines)
 					}
 					// Close this stream.
 					return
@@ -157,6 +158,7 @@ func (fs *fileStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 					// Stream from start always true on a stream reopen
 					if err := fs.stream(ctx, wg, waker, newfi, oneShot, true); err != nil {
 						glog.Info("stream(%s): new stream: %v", fs.sourcename, err)
+						close(fs.lines)
 					}
 					// We're at EOF so there's nothing left to read here.
 					return

--- a/internal/tailer/logstream/filestream_unix_test.go
+++ b/internal/tailer/logstream/filestream_unix_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/jaqx0r/mtail/internal/logline"
@@ -106,6 +107,111 @@ func TestFileStreamURL(t *testing.T) {
 	if v := <-fs.Lines(); v != nil {
 		t.Errorf("expecting filestream to be complete because stopped")
 	}
+}
+
+// manualWaker is a simple waker that lets the test directly signal wakeups
+// by closing and replacing the wake channel.
+type manualWaker struct {
+	wake chan struct{}
+}
+
+func (w *manualWaker) Wake() <-chan struct{} {
+	return w.wake
+}
+
+// wake signals the waker, closing the current channel and creating a new one.
+func (w *manualWaker) wakeAndReset() {
+	close(w.wake)
+	w.wake = make(chan struct{})
+}
+
+// TestFileStreamRotationPermissionDenied tests that when a rotation is detected
+// and the new file cannot be opened (permission denied), the filestream closes
+// its Lines channel so the tailer can clean up and retry later.
+func TestFileStreamRotationPermissionDenied(t *testing.T) {
+	testutil.SkipIfRoot(t)
+	var wg sync.WaitGroup
+
+	tmpDir := testutil.TestTempDir(t)
+
+	name := filepath.Join(tmpDir, "log")
+	f := testutil.TestOpenFile(t, name)
+	defer f.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mw := &manualWaker{wake: make(chan struct{})}
+
+	fs, err := logstream.New(ctx, &wg, mw, name, logstream.OneShotDisabled)
+	testutil.FatalIfErr(t, err)
+
+	expectedLines := []*logline.LogLine{
+		{Context: context.TODO(), Filename: name, Line: "1", Filenamehash: logline.GetHash(name)},
+	}
+	checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expectedLines, fs.Lines())
+
+	mw.wakeAndReset() // sync to EOF
+
+	testutil.WriteString(t, f, "1\n")
+	mw.wakeAndReset()
+
+	// Rotate: rename old file, create new file with no read permissions.
+	testutil.FatalIfErr(t, os.Rename(name, name+".1"))
+	f2, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0)
+	testutil.FatalIfErr(t, err)
+	f2.Close()
+
+	// Wake the stream to detect rotation.  The goroutine will see a new
+	// inode, try to open the new file, fail with permission denied, and
+	// (with our fix) close fs.lines.
+	mw.wakeAndReset()
+
+	// Wait for the Lines channel to close, indicating the goroutine exited.
+	ok, err := testutil.DoOrTimeout(func() (bool, error) {
+		select {
+		case _, stillOpen := <-fs.Lines():
+			return !stillOpen, nil
+		default:
+			return false, nil
+		}
+	}, time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("Lines channel not closed after rotation + permission denied")
+	}
+
+	// Wait for the goroutine to fully shut down.
+	wg.Wait()
+
+	// Fix permissions on the new file.
+	testutil.FatalIfErr(t, os.Chmod(name, 0o666))
+
+	// Now create a new stream; this should succeed.
+	fs2, err := logstream.New(ctx, &wg, mw, name, logstream.OneShotDisabled)
+	testutil.FatalIfErr(t, err)
+
+	expectedLines2 := []*logline.LogLine{
+		{Context: context.TODO(), Filename: name, Line: "2", Filenamehash: logline.GetHash(name)},
+	}
+	checkLineDiff2 := testutil.ExpectLinesReceivedNoDiff(t, expectedLines2, fs2.Lines())
+
+	f3, err := os.OpenFile(name, os.O_RDWR|os.O_APPEND, 0o666)
+	testutil.FatalIfErr(t, err)
+	defer f3.Close()
+
+	mw.wakeAndReset() // sync to EOF
+
+	testutil.WriteString(t, f3, "2\n")
+	mw.wakeAndReset()
+
+	cancel()
+	wg.Wait()
+
+	checkLineDiff()
+	checkLineDiff2()
 }
 
 // TestFileStreamOpenFailure is a unix-specific test because on Windows, it is not possible to create a file


### PR DESCRIPTION
Fixes https://github.com/google/mtail/issues/725

When a log file is rotated and the replacement file has incorrect permissions, the filestream goroutine fails to open the new file and exits without closing the fs.lines channel. This leaves the TailPath goroutine stuck and prevents the tailer from ever re-tailing the file, even after permissions are fixed.

Close fs.lines on failure in both the rotation and ESTALE paths so the tailer can clean up the dead logstream and retry later.