### PR TITLE
fix: rate-limit ESTALE reopen and handle ESTALE from stat (#505)

### DIFF
--- a/internal/tailer/logstream/filestream.go
+++ b/internal/tailer/logstream/filestream.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/jaqx0r/mtail/internal/logline"
@@ -113,17 +114,21 @@ func (fs *fileStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 
 			if err != nil && !errors.Is(err, io.EOF) {
 				logErrors.Add(fs.sourcename, 1)
-				// TODO: This could be generalised to check for any retryable
-				// errors, and end on unretriables; e.g. ESTALE looks
-				// retryable.
 				if errors.Is(err, syscall.ESTALE) {
 					glog.Infof("stream(%s): reopening stream due to %s", fs.sourcename, err)
-					// streamFromStart always true on a stream reopen
-					if nerr := fs.stream(ctx, wg, waker, fi, oneShot, true); nerr != nil {
+					// Rate-limit ESTALE retries to prevent CPU thrashing
+					// on NFS when the stale handle condition persists.
+					time.Sleep(time.Second)
+					newfi, serr := os.Stat(fs.pathname)
+					if serr != nil {
+						glog.Infof("stream(%s): stat after ESTALE: %v", fs.sourcename, serr)
+						close(fs.lines)
+						return
+					}
+					if nerr := fs.stream(ctx, wg, waker, newfi, oneShot, true); nerr != nil {
 						glog.Infof("stream(%s): new stream: %v", fs.sourcename, nerr)
 						close(fs.lines)
 					}
-					// Close this stream.
 					return
 				}
 				glog.Infof("stream(%s): read error: %v", fs.sourcename, err)
@@ -138,12 +143,12 @@ func (fs *fileStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 				newfi, serr := os.Stat(fs.pathname)
 				if serr != nil {
 					glog.Infof("stream(%s): stat error: %v", serr)
-					// If this is a NotExist error, then we should wrap up this
-					// goroutine. The Tailer will create a new logstream if the
-					// file is in the middle of a rotation and gets recreated
-					// in the next moment.  We can't rely on the Tailer to tell
-					// us we're deleted because the tailer can only tell us to
-					// cancel.
+					if errors.Is(serr, syscall.ESTALE) {
+						glog.V(2).Infof("stream(%s): stale NFS handle on stat, exiting", fs.sourcename)
+						lr.Finish(ctx)
+						close(fs.lines)
+						return
+					}
 					if os.IsNotExist(serr) {
 						glog.V(2).Infof("stream(%s): source no longer exists, exiting", fs.sourcename)
 						lr.Finish(ctx)

--- a/internal/tailer/logstream/filestream_unix_test.go
+++ b/internal/tailer/logstream/filestream_unix_test.go
@@ -214,6 +214,67 @@ func TestFileStreamRotationPermissionDenied(t *testing.T) {
 	checkLineDiff2()
 }
 
+// TestFileStreamStatErrorNotExist tests that when a file being tailed is
+// deleted, the filestream's stat call returns a NotExist error and the
+// stream properly closes its Lines channel, letting the tailer clean up
+// and retry later.  This exercises the same stat-error path that handles
+// ESTALE in production (both trigger stream shutdown).
+func TestFileStreamStatErrorNotExist(t *testing.T) {
+	var wg sync.WaitGroup
+
+	tmpDir := testutil.TestTempDir(t)
+
+	name := filepath.Join(tmpDir, "log")
+	f := testutil.TestOpenFile(t, name)
+	defer f.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mw := &manualWaker{wake: make(chan struct{})}
+
+	fs, err := logstream.New(ctx, &wg, mw, name, logstream.OneShotDisabled)
+	testutil.FatalIfErr(t, err)
+
+	expected := []*logline.LogLine{
+		{Context: context.TODO(), Filename: name, Line: "1", Filenamehash: logline.GetHash(name)},
+	}
+	checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, fs.Lines())
+
+	mw.wakeAndReset() // sync to EOF
+
+	testutil.WriteString(t, f, "1\n")
+	mw.wakeAndReset()
+
+	// Delete the file.  The stream will stat the path at the next EOF,
+	// get a NotExist error, and close its Lines channel.
+	testutil.FatalIfErr(t, os.Remove(name))
+	mw.wakeAndReset()
+
+	// Wait for the Lines channel to close.
+	ok, err := testutil.DoOrTimeout(func() (bool, error) {
+		select {
+		case _, stillOpen := <-fs.Lines():
+			return !stillOpen, nil
+		default:
+			return false, nil
+		}
+	}, time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("Lines channel not closed after file deletion")
+	}
+	wg.Wait()
+
+	checkLineDiff()
+
+	if v := <-fs.Lines(); v != nil {
+		t.Errorf("expecting filestream to be complete because file deleted")
+	}
+}
+
 // TestFileStreamOpenFailure is a unix-specific test because on Windows, it is not possible to create a file
 // that you yourself cannot read (minimum permissions are 0222).
 func TestFileStreamOpenFailure(t *testing.T) {


### PR DESCRIPTION
Three changes to prevent 100% CPU loops when mtail encounters stale NFS file handles on EFS:

1. **1s backoff before ESTALE reopen** — prevents tight open-read-ESTALE-close cycle when the stale condition persists.

2. **Stat + fresh fi on reopen** — passes the current file info instead of the original, avoiding a spurious rotation detection at the next EOF.

3. **Handle ESTALE from os.Stat** — the rotation check's stat can also return ESTALE on NFS; now treated like NotExist (close lines, let tailer retry via polling).

Also adds TestFileStreamStatErrorNotExist which exercises the same stat-error cleanup path.

Fixes #505