### PR TITLE
fix: remove Source from duplicate metric check to prevent dupe after SIGHUP reload (#636)

### DIFF
--- a/internal/metrics/store.go
+++ b/internal/metrics/store.go
@@ -53,9 +53,6 @@ func (s *Store) Add(m *Metric) error {
 			if v.Type != m.Type {
 				continue
 			}
-			if v.Source != m.Source {
-				continue
-			}
 			dupeIndex = i
 			glog.V(2).Infof("v keys: %v m.keys: %v", v.Keys, m.Keys)
 			// If a set of label keys has changed, discard

--- a/internal/metrics/store_test.go
+++ b/internal/metrics/store_test.go
@@ -90,6 +90,27 @@ func TestDuplicateMetric(t *testing.T) {
 	}
 }
 
+func TestDuplicateMetricWithDifferentSource(t *testing.T) {
+	// Simulates SIGHUP reload where the same metric from the same program
+	// has a different source location (line number changed due to file edit).
+	// Should still be treated as a duplicate and replaced, not appended.
+	s := NewStore()
+	m1 := NewMetric("foo", "prog", Counter, Int)
+	m1.SetSource("test.mtail:5:1")
+	testutil.FatalIfErr(t, s.Add(m1))
+
+	m2 := NewMetric("foo", "prog", Counter, Int)
+	m2.SetSource("test.mtail:11:1")
+	testutil.FatalIfErr(t, s.Add(m2))
+
+	if len(s.Metrics["foo"]) != 1 {
+		t.Fatalf("expected 1 metric after reload with changed source, got %d: %v", len(s.Metrics["foo"]), s.Metrics["foo"])
+	}
+	if s.Metrics["foo"][0].Source != "test.mtail:11:1" {
+		t.Fatalf("expected metric source to be updated to new source, got %q", s.Metrics["foo"][0].Source)
+	}
+}
+
 // A program can add a metric with the same name and of different type.
 // Prometheus behavior in this case is undefined.  @see
 // https://github.com/jaqx0r/mtail/issues/130


### PR DESCRIPTION
**Issue:** #636 — duplicate metric collected after SIGHUP reload

**Root cause:** In `Store.Add()`, duplicate metric detection compared `v.Source != m.Source`. The `Source` field is `filename:line:col` from the AST position. After SIGHUP reload with a modified file, the same metric declaration lands on a different line number, so the Source strings don`t match — the new metric is appended alongside the old one instead of replacing it.

**Fix:** Removed the Source comparison from the duplicate detection. Within the same program and metric type, the metric name uniquely identifies the metric regardless of source position. The Source field is purely informational (for JSON output) and should not be part of the identity check.

**Test:** Added `TestDuplicateMetricWithDifferentSource` to verify that a metric with the same program/name/type but different Source is treated as a duplicate and replaced, not appended.