### PR TITLE
fix: allow pattern concatenation to start with id_expr

### DIFF
--- a/internal/runtime/compiler/checker/checker_test.go
+++ b/internal/runtime/compiler/checker/checker_test.go
@@ -522,6 +522,35 @@ const X /foo/
 const X /foo/
 X {
 }`},
+	{"concat start with id plus regex", `
+const A /foo/
+A + /bar/ {
+}`},
+	{"concat start with id plus id", `
+const X /foo/
+const Y /bar/
+X + Y {
+}`},
+	{"concat start multi", `
+const X /foo/
+const Y /bar/
+X + Y + /baz/ {
+}`},
+	{"concat start match", `
+const X /foo/
+"" =~ X + /bar/ {
+}`},
+	{"const with id concat", `
+const A /foo/
+const B A + /bar/
+B {
+}`},
+	{"const with id id", `
+const A /foo/
+const B /bar/
+const C A + B
+C {
+}`},
 	{"match expression 3", `
 const X /foo/
 "a" =~ X {

--- a/internal/runtime/compiler/parser/parser.y
+++ b/internal/runtime/compiler/parser/parser.y
@@ -33,7 +33,7 @@ import (
 
 %type <n> stmt_list stmt arg_expr_list compound_stmt conditional_stmt conditional_expr expr_stmt
 %type <n> expr primary_expr multiplicative_expr additive_expr postfix_expr unary_expr assign_expr
-%type <n> rel_expr shift_expr bitwise_expr logical_expr indexed_expr id_expr concat_expr pattern_expr
+%type <n> rel_expr shift_expr bitwise_expr logical_expr indexed_expr id_expr concat_expr pattern_expr const_pattern concat_start
 %type <n> metric_declaration metric_decl_attr_spec decorator_declaration decoration_stmt regex_pattern match_expr
 %type <n> delete_stmt metric_name_spec builtin_expr arg_expr
 %type <kind> metric_type_spec
@@ -133,7 +133,7 @@ stmt
   {
     $$ = &ast.NextStmt{tokenpos(mtaillex)}
   }
-  | CONST id_expr opt_nl concat_expr
+  | CONST id_expr opt_nl const_pattern
   {
     $$ = &ast.PatternFragment{ID: $2, Expr: $4}
   }
@@ -205,6 +205,18 @@ conditional_expr
   {
     $$ = &ast.BinaryExpr{
       LHS: &ast.UnaryExpr{P: tokenpos(mtaillex), Expr: $1, Op: MATCH},
+      RHS: $4,
+      Op: $2,
+    }
+  }
+  | concat_start
+  {
+    $$ = &ast.UnaryExpr{P: tokenpos(mtaillex), Expr: &ast.PatternExpr{Expr: $1}, Op: MATCH}
+  }
+  | concat_start logical_op opt_nl logical_expr
+  {
+    $$ = &ast.BinaryExpr{
+      LHS: &ast.UnaryExpr{P: tokenpos(mtaillex), Expr: &ast.PatternExpr{Expr: $1}, Op: MATCH},
       RHS: $4,
       Op: $2,
     }
@@ -360,6 +372,14 @@ match_expr
   {
     $$ = &ast.BinaryExpr{LHS: $1, RHS: $4, Op: $2}
   }
+  | primary_expr match_op opt_nl concat_start
+  {
+    $$ = &ast.BinaryExpr{
+      LHS: $1,
+      RHS: &ast.PatternExpr{Expr: $4},
+      Op: $2,
+    }
+  }
   ;
 
 match_op
@@ -375,6 +395,42 @@ pattern_expr
   : concat_expr
   {
     $$ = &ast.PatternExpr{Expr: $1}
+  }
+  ;
+
+/* Const pattern fragment expression allows identifiers in addition to regex patterns. */
+const_pattern
+  : regex_pattern
+  { $$ = $1 }
+  | id_expr
+  { $$ = $1 }
+  | const_pattern PLUS opt_nl regex_pattern
+  {
+    $$ = &ast.BinaryExpr{LHS: $1, RHS: $4, Op: PLUS}
+  }
+  | const_pattern PLUS opt_nl id_expr
+  {
+    $$ = &ast.BinaryExpr{LHS: $1, RHS: $4, Op: PLUS}
+  }
+  ;
+
+/* Concatenation start expression handles id_expr at the start of a pattern concatenation. */
+concat_start
+  : id_expr PLUS opt_nl regex_pattern
+  {
+    $$ = &ast.BinaryExpr{LHS: $1, RHS: $4, Op: PLUS}
+  }
+  | id_expr PLUS opt_nl id_expr
+  {
+    $$ = &ast.BinaryExpr{LHS: $1, RHS: $4, Op: PLUS}
+  }
+  | concat_start PLUS opt_nl regex_pattern
+  {
+    $$ = &ast.BinaryExpr{LHS: $1, RHS: $4, Op: PLUS}
+  }
+  | concat_start PLUS opt_nl id_expr
+  {
+    $$ = &ast.BinaryExpr{LHS: $1, RHS: $4, Op: PLUS}
   }
   ;
 

--- a/internal/runtime/compiler/parser/parser_test.go
+++ b/internal/runtime/compiler/parser/parser_test.go
@@ -400,6 +400,36 @@ const X /foo/
 X {
 }`},
 
+	{"concat start with id plus regex", `
+const A /foo/
+A + /bar/ {
+}`},
+	{"concat start with id plus id", `
+const X /foo/
+const Y /bar/
+X + Y {
+}`},
+	{"concat start multi", `
+const X /foo/
+const Y /bar/
+X + Y + /baz/ {
+}`},
+	{"concat start match", `
+const X /foo/
+$uri =~ X + /bar/ {
+}`},
+	{"const with id concat", `
+const A /foo/
+const B A + /bar/
+B {
+}`},
+	{"const with id id", `
+const A /foo/
+const B /bar/
+const C A + B
+C {
+}`},
+
 	{"match expression 1", `
 $foo =~ /bar/ {
 }
@@ -671,8 +701,7 @@ var parsePositionTests = []struct {
 		"const ID\n" +
 			"/foo/ +\n" +
 			"/bar/",
-		// TODO: Update position for the first token to `1, 0, 4` when position tracking is fixed
-		[]*position.Position{{"multiline regex", 1, 4, 4}, {"multiline regex", 2, 0, 4}},
+		[]*position.Position{{"multiline regex", 1, 0, 4}, {"multiline regex", 2, 0, 4}},
 	},
 }
 

--- a/internal/runtime/runtime_integration_test.go
+++ b/internal/runtime/runtime_integration_test.go
@@ -1072,6 +1072,70 @@ N && 1 {
 		errs:    0,
 		metrics: nil,
 	},
+	{
+		name: "const with id concat pattern",
+		prog: `counter c
+const GREET /hello/
+const SEP / /
+const PUNCT /world/
+const FULL GREET + SEP + PUNCT
+FULL {
+  c++
+}
+`,
+		log: `hello world
+other
+hello world
+`,
+		errs: 0,
+		metrics: metrics.MetricSlice{
+			{
+				Name:    "c",
+				Program: "const with id concat pattern",
+				Kind:    metrics.Counter,
+				Type:    metrics.Int,
+				Keys:    []string{},
+				LabelValues: []*metrics.LabelValue{
+					{
+						Value: &datum.Int{
+							Value: 2,
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "concat start match",
+		prog: `counter c
+const X /foo/
+/(?P<line>.*)/ {
+  $line =~ X + /bar/ {
+    c++
+  }
+}
+`,
+		log: `foobar
+baz
+`,
+		errs: 0,
+		metrics: metrics.MetricSlice{
+			{
+				Name:    "c",
+				Program: "concat start match",
+				Kind:    metrics.Counter,
+				Type:    metrics.Int,
+				Keys:    []string{},
+				LabelValues: []*metrics.LabelValue{
+					{
+						Value: &datum.Int{
+							Value: 1,
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestRuntimeEndToEnd(t *testing.T) {


### PR DESCRIPTION
**Problem:** `const C A + B` and `$uri =~ A + /pattern/` both fail to parse with "syntax error" because `concat_expr` in the grammar required the concatenation to start with a `regex_pattern` literal (`/foo/`), not an `id_expr` (const pattern reference). Adding `concat_expr: id_expr` caused reduce-reduce conflicts with `indexed_expr: id_expr`.

**Solution:** Two new non-terminals, each used only in contexts where concatenation is expected.

**Changes:**
- `parser.y`: Added `const_pattern` and `concat_start` rules; updated `CONST` production to use `const_pattern`; added `concat_start` alternatives to `match_expr` and `conditional_expr`.
- `parser_test.go`: 6 new round-trip parse tests.
- `checker_test.go`: 6 new checker-valid tests.
- `runtime_integration_test.go`: 2 new end-to-end runtime tests.
- Fixed the long-standing TODO in `parsePositionTests` for `multiline_regex`.

Fixes google/mtail#340.