### PR TITLE
test: add coverage for const patterns as standalone match conditions (#191)

### DIFF
--- a/internal/runtime/compiler/checker/checker_test.go
+++ b/internal/runtime/compiler/checker/checker_test.go
@@ -607,6 +607,28 @@ N {
 const N /n/
 N && 1 {
 }`},
+
+	{"const pattern with named capref as cond", `
+counter c
+const P /(?P<x>n)/
+P {
+  c++
+}`},
+
+	{"const pattern with positional capref as cond", `
+counter c
+const P /(n)/
+P {
+  c += $1
+}`},
+
+	{"const pattern in a binary expr in cond", `
+counter c
+const P /(?P<x>n)/
+P && 1 {
+  c++
+}`},
+
 	{"negative numbers in capture groups", `
 gauge foo
 /(?P<value_ms>-?\d+)/ {

--- a/internal/runtime/runtime_integration_test.go
+++ b/internal/runtime/runtime_integration_test.go
@@ -1106,6 +1106,66 @@ hello world
 		},
 	},
 	{
+		name: "const pattern as match condition with named capref",
+		prog: `counter c
+const A /(?P<x>n)/
+A {
+  c++
+}
+`,
+		log: `n
+x
+n
+`,
+		errs: 0,
+		metrics: metrics.MetricSlice{
+			{
+				Name:    "c",
+				Program: "const pattern as match condition with named capref",
+				Kind:    metrics.Counter,
+				Type:    metrics.Int,
+				Keys:    []string{},
+				LabelValues: []*metrics.LabelValue{
+					{
+						Value: &datum.Int{
+							Value: 2,
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "const pattern as match condition simple",
+		prog: `counter c
+const A /n/
+A {
+  c++
+}
+`,
+		log: `n
+x
+n
+`,
+		errs: 0,
+		metrics: metrics.MetricSlice{
+			{
+				Name:    "c",
+				Program: "const pattern as match condition simple",
+				Kind:    metrics.Counter,
+				Type:    metrics.Int,
+				Keys:    []string{},
+				LabelValues: []*metrics.LabelValue{
+					{
+						Value: &datum.Int{
+							Value: 2,
+						},
+					},
+				},
+			},
+		},
+	},
+	{
 		name: "concat start match",
 		prog: `counter c
 const X /foo/


### PR DESCRIPTION
Issue #191 reported that const patterns could not be used alone as a match condition without a `// +` prefix, triggering a "capref not defined" compiler error.

The functional fix was already applied in commits 43852d46 and c16d4929 (rewriting IndexedExpr of type Pattern to PatternExpr in the checker, and wrapping PatternExpr conditions with UnaryExpr(MATCH)). This change adds the missing test coverage.

**Checker tests (checker_test.go):**
- `const pattern with named capref as cond` — const `P /(?P<x>n)/` used as `P { c++ }`
- `const pattern with positional capref as cond` — const `P /(n)/` used as `P { c += $1 }`
- `const pattern in a binary expr in cond` — const `P /(?P<x>n)/` used as `P && 1 { c++ }`

**Runtime integration tests (runtime_integration_test.go):**
- `const pattern as match condition with named capref` — end-to-end test with `const A /(?P<x>n)/` used as `A { c++ }`; verifies two matches on input "n\nx\nn"
- `const pattern as match condition simple` — end-to-end test with `const A /n/` used as `A { c++ }`; verifies two matches

All 21 internal tests pass.