### PR TITLE
fix(checker): allow chained match expressions with numbered caprefs

### DIFF
--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -196,6 +196,40 @@ operator, or to negate the match the `!~`, like so:
   }
 ```
 
+### Chaining match conditions
+
+Multiple patterns can be combined in a single condition using the `&&` and `||`
+logical operators.  This is useful for filtering log lines based on both the
+filename and the line content:
+
+```mtail
+getfilename() =~ /apache/ && /HTTP\/1\.1/ {
+    apache_http11_requests++
+}
+```
+
+Both patterns are tried in order (left to right), and the condition short
+circuits as normal for `&&` and `||`.
+
+When multiple patterns appear in the same condition, each registers its capture
+group references (such as `$0`, `$1`, etc.) in the same scope.  The capture
+group references after the condition refer to the *last* executed match,
+consistent with the runtime order of evaluation:
+
+```mtail
+const PAT /n/
+/(?P<word>\w+)/ && PAT {
+    # $0 refers to PAT's match, not the first pattern's match.
+    # Use named capture groups if you need the first pattern's captures:
+    # $word still refers to the \w+ capture group from the first pattern.
+}
+```
+
+This is known as *last pattern match wins* semantics.  `mtail` will emit a
+notice when numbered capture group bindings are updated in a chained match
+expression.  Use named capture groups for unambiguous references when chaining
+patterns.
+
 ## Storing intermediate state
 
 Hidden metrics are metrics that can be used for internal state and are never

--- a/internal/runtime/compiler/checker/checker.go
+++ b/internal/runtime/compiler/checker/checker.go
@@ -884,7 +884,16 @@ func (c *checker) checkRegex(pattern string, n ast.Node) {
 			sym.Binding = n
 			sym.Addr = i
 			if alt := c.scope.Insert(sym); alt != nil {
-				c.errors.Add(n.Pos(), fmt.Sprintf("Redeclaration of capture group `%s' previously declared at %s", sym.Name, alt.Pos))
+				// If this is a numbered capref, we allow chained match
+				// expressions to each define the same implicit capture
+				// groups.  The last pattern's binding is used at runtime
+				// ("last match wins").
+				if capref == "" {
+					alt.Binding = n
+					glog.Infof("Update of capref `%s' binding in chained match expression", sym.Name)
+				} else {
+					c.errors.Add(n.Pos(), fmt.Sprintf("Redeclaration of capture group `%s' previously declared at %s", sym.Name, alt.Pos))
+				}
 				// No return, let this loop collect all errors
 			}
 			if capref != "" {

--- a/internal/runtime/compiler/checker/checker_test.go
+++ b/internal/runtime/compiler/checker/checker_test.go
@@ -333,11 +333,6 @@ l++=l
 		[]string{"dec non var:1:1-16: Can't assign to expression; expecting a variable here."},
 	},
 
-	// TODO(jaq): This is an instance of bug #190, the capref is ambiguous.
-	// 	{"regexp with no zero capref",
-	// 		`//||/;0/ {$0||// {}}
-	// `, []string{"regexp with no zero capref:1:5-6: Nonexistent capref =."}},
-
 	{
 		"cmp to None",
 		`strptime("","")<5{}
@@ -646,6 +641,12 @@ subst(/\d+/, "d", "1234")
 text value
 value = subst(/[a-zA-Z]+/, "a", "1234abcd")
 value = subst(/\d+/, "d", value)
+`},
+	{"chained match OR capref", `
+const X /x/
+// || X {
+    $0
+}
 `},
 }
 

--- a/internal/runtime/compiler/symbol/symtab.go
+++ b/internal/runtime/compiler/symbol/symtab.go
@@ -6,6 +6,7 @@ package symbol
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/jaqx0r/mtail/internal/runtime/compiler/errors"
@@ -144,7 +145,14 @@ func (s *Scope) Check(errors *errors.ErrorList) {
 	for _, symList := range s.Symbols {
 		multiple := len(symList) > 1
 		for i, sym := range symList {
-			if multiple && i > 0{
+			if multiple && i > 0 {
+				if sym.Kind == CaprefSymbol {
+					// Numbered caprefs may be redeclared in chained
+					// match expressions (last pattern wins).
+					if _, err := strconv.Atoi(sym.Name); err == nil {
+						continue
+					}
+				}
 				errors.Add(sym.Pos, fmt.Sprintf("Redeclaration of %s `%s' previously declared at %s", sym.Kind, sym.Name, symList[0].Pos))
 				continue
 			}

--- a/internal/runtime/runtime_integration_test.go
+++ b/internal/runtime/runtime_integration_test.go
@@ -1196,6 +1196,36 @@ baz
 			},
 		},
 	},
+	{
+		name: "chained match capref",
+		prog: `counter c
+const PAT /n/
+/(\w+)/ && PAT {
+    c++
+}
+`,
+		log: `n
+x
+n
+`,
+		errs: 0,
+		metrics: metrics.MetricSlice{
+			{
+				Name:    "c",
+				Program: "chained match capref",
+				Kind:    metrics.Counter,
+				Type:    metrics.Int,
+				Keys:    []string{},
+				LabelValues: []*metrics.LabelValue{
+					{
+						Value: &datum.Int{
+							Value: 2,
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestRuntimeEndToEnd(t *testing.T) {


### PR DESCRIPTION
Expressions like `getfilename() =~ "x" && /pattern/` previously threw
"Redeclaration of capture group 0" because both patterns register
numbered caprefs in the same scope.  The workaround was to nest the
second match in an inner block.

This change implements "last pattern match wins" semantics for numbered
capture groups only:

- When a numbered capref ($0, $1, etc.) is redeclared in the same scope,
  the checker emits a notice and updates the existing symbol Binding
  to point to the last pattern PatternExpr node.  Named capref
  redeclaration remains an error (genuinely ambiguous).

- Scope.Check skips the redeclaration error for numbered caprefs, which
  are expected to be multi-defined in chained condition scopes.

- A new "Chaining match conditions" subsection in the Programming Guide
  documents the feature and the "last wins" semantics.

- Tests: checker test exercises two numbered capref 0 declarations
  with `||`; runtime integration test verifies correct execution of
  `/(\w+)/ && PAT`.

Fixes google/mtail#190