### PR TITLE
feat: add `defined()` builtin to test if a capture group was matched

### DIFF
--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -446,8 +446,20 @@ counter total
 }
 ```
 
-`mtail` does not presently have a way to test if a capture group is defined or
-not.
+Use the `defined()` builtin to test if a capture group was matched:
+
+```
+counter total
+
+/^[a-z]+ ((?P<response_size>\d+)|-)$/ {
+  defined($response_size) {
+    total = $response_size
+  }
+}
+```
+
+`defined()` takes a capture group reference and returns true if it was
+matched in the current line.
 
 ## Parsing numbers with extra characters
 

--- a/internal/runtime/code/opcodes.go
+++ b/internal/runtime/code/opcodes.go
@@ -78,6 +78,9 @@ const (
 	Subst
 	Rsubst
 
+	// Capture group queries.
+	Defined // Check if a capture group is defined.
+
 	lastOpcode
 )
 
@@ -140,6 +143,7 @@ var opNames = map[Opcode]string{
 	Scmp:        "scmp",
 	Subst:       "subst",
 	Rsubst:      "rsubst",
+	Defined:     "defined",
 }
 
 func (o Opcode) String() string {

--- a/internal/runtime/compiler/checker/checker.go
+++ b/internal/runtime/compiler/checker/checker.go
@@ -276,6 +276,10 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 		switch n.Cond.(type) {
 		case *ast.BinaryExpr, *ast.OtherwiseStmt, *ast.UnaryExpr:
 			// OK as conditions
+		case *ast.BuiltinExpr:
+			if !types.Equals(n.Cond.Type(), types.Bool) {
+				c.errors.Add(n.Cond.Pos(), fmt.Sprintf("Can't interpret %s as a boolean expression here.\n\tTry using comparison operators to make the condition explicit.", n.Cond.Type()))
+			}
 		case *ast.PatternExpr:
 			// If the parser saw an IDTerm with type Pattern, then we know it's really a pattern constant and need to wrap it in an unary match in this context.
 			cond := &ast.UnaryExpr{Expr: n.Cond, Op: parser.MATCH}
@@ -819,6 +823,12 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 		case "tolower":
 			if !types.Equals(gotType.Args[0], types.String) {
 				c.errors.Add(n.Args.(*ast.ExprList).Children[0].Pos(), fmt.Sprintf("Expecting a String for argument 1 of tolower(), not %v.", gotType.Args[0]))
+				n.SetType(types.Error)
+				return n
+			}
+		case "defined":
+			if _, ok := n.Args.(*ast.ExprList).Children[0].(*ast.CaprefTerm); !ok {
+				c.errors.Add(n.Args.(*ast.ExprList).Children[0].Pos(), "defined() expects a capture group reference as its argument")
 				n.SetType(types.Error)
 				return n
 			}

--- a/internal/runtime/compiler/codegen/codegen.go
+++ b/internal/runtime/compiler/codegen/codegen.go
@@ -330,6 +330,31 @@ func (c *codegen) VisitBefore(node ast.Node) (ast.Visitor, ast.Node) {
 		c.obj.LogRestriction = append(c.obj.LogRestriction, n.Filters...)
 		return nil, n
 
+	case *ast.BuiltinExpr:
+		if n.Name == "defined" {
+			// Don't walk children: defined() requires special codegen
+			// to avoid emitting Capref/S2i for its capref argument,
+			// which would cause a runtime error on undefined groups.
+			args := n.Args.(*ast.ExprList).Children
+			if len(args) != 1 {
+				c.errorf(n.Pos(), "defined expects 1 argument, got %d", len(args))
+				return nil, n
+			}
+			capref, ok := args[0].(*ast.CaprefTerm)
+			if !ok {
+				c.errorf(n.Pos(), "defined expects a capture group reference")
+				return nil, n
+			}
+			if capref.Symbol == nil || capref.Symbol.Binding == nil {
+				c.errorf(n.Pos(), "No regular expression bound to capref %q", capref.Name)
+				return nil, n
+			}
+			rn := capref.Symbol.Binding.(*ast.PatternExpr)
+			c.emit(n, code.Push, rn.Index)
+			c.emit(n, code.Defined, capref.Symbol.Addr)
+			return nil, n
+		}
+
 	case *ast.BinaryExpr:
 		switch n.Op {
 		case parser.AND:

--- a/internal/runtime/compiler/parser/lexer.go
+++ b/internal/runtime/compiler/parser/lexer.go
@@ -42,6 +42,7 @@ var keywords = map[string]Kind{
 // List of builtin functions.  Keep this list sorted!
 var builtins = []string{
 	"bool",
+	"defined",
 	"float",
 	"getfilename",
 	"int",

--- a/internal/runtime/compiler/types/types.go
+++ b/internal/runtime/compiler/types/types.go
@@ -256,6 +256,7 @@ var (
 var Builtins = map[string]Type{
 	"int":         Function(NewVariable(), Int),
 	"bool":        Function(NewVariable(), Bool),
+	"defined":     Function(NewVariable(), Bool),
 	"float":       Function(NewVariable(), Float),
 	"string":      Function(NewVariable(), String),
 	"timestamp":   Function(Int),

--- a/internal/runtime/runtime_integration_test.go
+++ b/internal/runtime/runtime_integration_test.go
@@ -258,6 +258,35 @@ test -
 		},
 	},
 	{
+		"defined capture group",
+		`counter total
+/^[a-z]+ ((?P<response_size>\d+)|-)$/ {
+  defined($response_size) {
+    total = $response_size
+  }
+}`,
+		`test 99
+test -
+`,
+		0,
+		metrics.MetricSlice{
+			{
+				Name:    "total",
+				Program: "defined capture group",
+				Kind:    metrics.Counter,
+				Type:    metrics.Int,
+				Keys:    []string{},
+				LabelValues: []*metrics.LabelValue{
+					{
+						Value: &datum.Int{
+							Value: 99,
+						},
+					},
+				},
+			},
+		},
+	},
+	{
 		"add_assign_float",
 		`gauge metric
 /(\d+\.\d+)/ {

--- a/internal/runtime/vm/vm.go
+++ b/internal/runtime/vm/vm.go
@@ -855,6 +855,32 @@ func (v *VM) execute(t *thread, i code.Instr) {
 		}
 		t.Push(len(s))
 
+	case code.Defined:
+		// Check if a capture group is defined (was matched) in the current match.
+		val := t.Pop()
+		re, ok := val.(int)
+		if !ok {
+			v.errorf("Invalid re index %v, not an int", val)
+			return
+		}
+		op, ok := i.Operand.(int)
+		if !ok {
+			v.errorf("Invalid operand %v, not an int", i.Operand)
+			return
+		}
+		m, ok := t.matches[re]
+		if !ok {
+			v.errorf("No match result for regex index %d", re)
+			return
+		}
+		if len(m.indices) >= 2*(op+1) && m.indices[2*op] != -1 {
+			t.matched = true
+			t.Push(true)
+		} else {
+			t.matched = false
+			t.Push(false)
+		}
+
 	case code.S2i:
 		base := 10
 		var err error


### PR DESCRIPTION
When a named capture group is inside a regex alternation like `((?P<response_size>\d+)|-)`, the inner group is not matched when the alternative branch matches (e.g., `-`). Previously, using `$response_size` in this case returned an empty string that failed `strconv.ParseInt`, causing a runtime error, and there was no way to test whether a capture group was defined.

This adds a `defined()` builtin that checks at runtime whether a capture group was actually matched:

```
/^[a-z]+ ((?P<response_size>\d+)|-)$/ {
  defined($response_size) {
    total = $response_size
  }
}
```

Implementation:
- New `Defined` opcode in the VM that checks `m.indices[2*n] != -1`
- Parser: added `"defined"` to the lexer builtins list
- Type system: `defined` accepts any type and returns `Bool`
- Checker: validates argument is a `CaprefTerm`; permits `Bool`-typed `BuiltinExpr` as a condition in `CondStmt`
- Codegen: `defined()` is handled entirely in `VisitBefore` (returning `nil` prevents child walking) to avoid emitting the normal `Capref`/`S2i` bytecode that would error on undefined groups; emits `Push regexIndex` + `Defined caprefAddr` instead
- Integration test covers both defined and undefined cases

Fixes https://github.com/google/mtail/issues/267