### PR TITLE
chore: remove no-longer-needed // + workaround from example programs (#191)

### DIFF
--- a/examples/lighttpd.mtail
+++ b/examples/lighttpd.mtail
@@ -10,7 +10,7 @@ counter bytes_in by status
 counter requests by proxy_cache
 
 
-const ACCESSLOG_RE // +
+const ACCESSLOG_RE
     /(?P<proxied_for>\S+) (?P<request_ip>\S+) (?P<authuser>\S+)/ +
     / \[(?P<access_time>[^\]]+)\] "(?P<http_method>\S+) (?P<url>.+?) / +
     /(?P<protocol>\S+)" (?P<status>\d+) (?P<bytes_body>\d+) (?P<bytes_in>\d+)/ +
@@ -20,7 +20,7 @@ const ACCESSLOG_RE // +
 
 # /var/log/lighttpd/access.log
 getfilename() =~ /lighttpd.access.log/ {
-  // + ACCESSLOG_RE {
+  ACCESSLOG_RE {
     # Parse an accesslog entry.
     $url == "/healthz" {
       # nothing

--- a/examples/mysql_slowqueries.mtail
+++ b/examples/mysql_slowqueries.mtail
@@ -50,7 +50,7 @@ const END_QUERY_LINE /.*;$/
 
 settime(time)
 
-// + USER_HOST {
+USER_HOST {
   user = $1
   host = $2
 }
@@ -59,7 +59,7 @@ user == "" {
   stop
 }
 
-// + QUERY_TIME {
+QUERY_TIME {
   tmp_query_time = $1
   tmp_lock_time = $2
   query_time_overall_sum += tmp_query_time
@@ -68,7 +68,7 @@ user == "" {
   lock_time_total_count++
 }
 
-// + FULL_QUERY_LINE {
+FULL_QUERY_LINE {
   # We should have everything we need now.
   query_type = tolower($1)
   service = $2
@@ -76,7 +76,7 @@ user == "" {
   lock_time[query_type, host, service, user] += tmp_lock_time
 }
 
-// + UNINSTRUMENTED_QUERY_LINE {
+UNINSTRUMENTED_QUERY_LINE {
   # We should have everything we need now.
   query_type = tolower($1)
   service = "n/a"
@@ -84,12 +84,12 @@ user == "" {
   lock_time[query_type, host, service, user] += tmp_lock_time
 }
 
-// + PARTIAL_QUERY_LINE {
+PARTIAL_QUERY_LINE {
   query_type = tolower($1)
   partial = 1
 }
 
-// + END_QUERY_LINE && partial == 1 {
+END_QUERY_LINE && partial == 1 {
   partial = 0
   /.*# (.*)$/ {
     service = $1

--- a/examples/postfix.mtail
+++ b/examples/postfix.mtail
@@ -42,7 +42,7 @@ const QMGR_REMOVE_LINE /: removed$/
   # buckets: 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3
 
   $application == "lmtp" {
-    // + DELIVERY_DELAY_LINE {
+    DELIVERY_DELAY_LINE {
       # 1st field: before_queue_manager
       postfix_lmtp_delivery_delay_seconds["before_queue_manager"] = $bqm
 
@@ -62,7 +62,7 @@ const QMGR_REMOVE_LINE /: removed$/
   # buckets: 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3
 
   $application == "pipe" {
-    // + DELIVERY_DELAY_LINE {
+    DELIVERY_DELAY_LINE {
       # 1st field: before_queue_manager
       postfix_pipe_delivery_delay_seconds[$relay]["before_queue_manager"] = $bqm
 
@@ -89,11 +89,11 @@ const QMGR_REMOVE_LINE /: removed$/
   counter postfix_qmgr_messages_removed_total
 
   $application == "qmgr" {
-    // + QMGR_INSERT_LINE {
+    QMGR_INSERT_LINE {
       postfix_qmgr_messages_inserted_recipients = $nrcpt
       postfix_qmgr_messages_inserted_size_bytes = $size
       }
-    // + QMGR_REMOVE_LINE {
+    QMGR_REMOVE_LINE {
       postfix_qmgr_messages_removed_total++
       }
     }
@@ -106,7 +106,7 @@ const QMGR_REMOVE_LINE /: removed$/
   counter postfix_smtp_tls_connections_total by trust, protocol, cipher, secret_bits, algorithm_bits
 
   $application == "smtp" {
-      // + DELIVERY_DELAY_LINE {
+      DELIVERY_DELAY_LINE {
         # 1st field: before_queue_manager
         postfix_smtp_delivery_delay_seconds["before_queue_manager"] = $bqm
 
@@ -120,7 +120,7 @@ const QMGR_REMOVE_LINE /: removed$/
       postfix_smtp_delivery_delay_seconds["transmission"] = $tx
       }
 
-      // + SMTP_TLS_LINE {
+      SMTP_TLS_LINE {
         postfix_smtp_tls_connections_total[$1][$2][$3][$4][$5]++
       }
     }
@@ -175,7 +175,7 @@ const QMGR_REMOVE_LINE /: removed$/
     /warning: \S+: SASL \S+ authentication failed: / {
       postfix_smtpd_sasl_authentication_failures_total++
       }
-    // + SMTPD_TLS_LINE {
+    SMTPD_TLS_LINE {
       postfix_smtpd_tls_connections_total[$1][$2][$3][$4][$5]++
       }
     }

--- a/examples/vsftpd.mtail
+++ b/examples/vsftpd.mtail
@@ -27,7 +27,7 @@ def vsftpd_timestamp {
   }
 }
 
-const XFERLOG_RE // +
+const XFERLOG_RE
     # e.g. 1 172.18.115.36 528
     # time spent transferring
     /\s(?P<transfertime>\d+)/ +
@@ -57,7 +57,7 @@ const XFERLOG_RE // +
     # completion status
     /\s(?P<completionstatus>\S)/
 
-const VSFTPD_LOG_RE // +
+const VSFTPD_LOG_RE
     / \[pid \d+\]/ +
     /( \[\w+\])?/ +
     / (?P<command>CONNECT|OK LOGIN|OK UPLOAD|FTP (command|response)):/ +
@@ -70,7 +70,7 @@ const PAYLOAD_COMMAND_RE /^"(\w{4})[" -]/
 
 @vsftpd_timestamp {
   getfilename() =~ /xferlog/ {
-    // + XFERLOG_RE {
+    XFERLOG_RE {
       # Handles log entries from the wuftpd format xferlog.
       $direction == "i" {
         direction = "incoming"
@@ -87,7 +87,7 @@ const PAYLOAD_COMMAND_RE /^"(\w{4})[" -]/
   }
   
   getfilename() =~ /vsftpd.log/ {
-    // + VSFTPD_LOG_RE {
+    VSFTPD_LOG_RE {
       # Handle vsftpd.log log file."""
       $command == "CONNECT" {
         sessions[$client] = timestamp()
@@ -101,7 +101,7 @@ const PAYLOAD_COMMAND_RE /^"(\w{4})[" -]/
         uploads++
       }
       $command == "FTP command" {
-        $payload =~ // + PAYLOAD_COMMAND_RE {
+        $payload =~ PAYLOAD_COMMAND_RE {
           commands[$1]++
           
           $1 == "QUIT" {
@@ -111,7 +111,7 @@ const PAYLOAD_COMMAND_RE /^"(\w{4})[" -]/
         }
       }
       $command == "FTP response" {
-        $payload =~ // + PAYLOAD_RESPONSE_RE {
+        $payload =~ PAYLOAD_RESPONSE_RE {
           responses[$1]++
         }
       }

--- a/subject_summarizer.mtail
+++ b/subject_summarizer.mtail
@@ -7,6 +7,6 @@ counter subject_lines_seen by subject
 
 const SUBJECT_LINE /^Subject: (.*)$/
 
-// + SUBJECT_LINE {
+SUBJECT_LINE {
   subject_lines_seen[$1] ++
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #462 which fixed the checker/codegen for issue google/mtail#191
(const patterns as standalone match conditions). Now that const
patterns are properly handled, remove the `// +` workaround from all
example programs that still used it.

## Changes

Removed 22 `// +` instances across 5 example programs:

| File | Type | Sites |
|------|------|-------|
| `lighttpd.mtail` | const def + match cond | 2 |
| `vsftpd.mtail` | 2 const defs + 4 match/=~ sites | 6 |
| `mysql_slowqueries.mtail` | match conds | 6 |
| `postfix.mtail` | match conds | 7 |
| `subject_summarizer.mtail` | match cond | 1 |

Three categories of simplification:

1. **Const definitions**: `const NAME // + /re/ + ...` becomes `const NAME /re/ + ...`
2. **Match conditions**: `// + NAME { ... }` becomes `NAME { ... }`
3. **`=~` RHS**: `$x =~ // + NAME { ... }` becomes `$x =~ NAME { ... }`

## Verification

- `bazel test //internal/mtail:mtail_test` passes (exercises these programs against golden output)
- No remaining `// +` instances in any of the 5 files