### PR TITLE
chore: Fix format types in `Errorf`s.

### DIFF
--- a/internal/runtime/vm/vm.go
+++ b/internal/runtime/vm/vm.go
@@ -208,7 +208,7 @@ func compareInt(a, b int64, opnd int) (bool, error) {
 	case 1:
 		return a > b, nil
 	default:
-		return false, errors.Errorf("unexpected operator type %q", opnd)
+		return false, errors.Errorf("unexpected operator type %d", opnd)
 	}
 }
 
@@ -221,7 +221,7 @@ func compareFloat(a, b float64, opnd int) (bool, error) {
 	case 1:
 		return a > b, nil
 	default:
-		return false, errors.Errorf("unexpected operator type %q", opnd)
+		return false, errors.Errorf("unexpected operator type %d", opnd)
 	}
 }
 
@@ -234,7 +234,7 @@ func compareString(a, b string, opnd int) (bool, error) {
 	case 1:
 		return a > b, nil
 	default:
-		return false, errors.Errorf("unexpected operator type %q", opnd)
+		return false, errors.Errorf("unexpected operator type %d", opnd)
 	}
 }
 


### PR DESCRIPTION
Fixes a build error with the new nogo brought in by `rules_go` 0.61.  https://github.com/jaqx0r/mtail/actions/runs/27034482392/job/79794857908?pr=467