### PR TITLE
metrics: enforce per-metric cardinality Limit in GetDatum (not just Store.Gc)

### DIFF
--- a/internal/metrics/metric.go
+++ b/internal/metrics/metric.go
@@ -157,7 +157,20 @@ func (m *Metric) GetDatum(labelvalues ...string) (d datum.Datum, err error) {
 	if lv := m.FindLabelValueOrNil(labelvalues); lv != nil {
 		d = lv.Value
 	} else {
-		// TODO Check m.Limit and expire old data
+		// Enforce the per-metric cardinality Limit before creating a new
+		// series.  Limit == 0 means unbounded (the default, unchanged).  This
+		// mirrors Store.Gc's evict-oldest policy so the cap is also honoured
+		// between GC cycles, not just at GC time -- otherwise a program that
+		// labels a metric by a high-cardinality field (request path,
+		// User-Agent, ...) can grow without bound until the next Gc tick.
+		// Refs google/mtail#1006, #61.
+		if m.Limit > 0 {
+			for len(m.LabelValues) >= m.Limit {
+				if !m.removeOldestDatumLocked() {
+					break
+				}
+			}
+		}
 		switch m.Type {
 		case Int:
 			d = datum.NewInt()
@@ -182,19 +195,27 @@ func (m *Metric) GetDatum(labelvalues ...string) (d datum.Datum, err error) {
 
 // RemoveOldestDatum scans the Metric's LabelValues for the Datum with the oldest timestamp, and removes it.
 func (m *Metric) RemoveOldestDatum() {
+	m.Lock()
+	defer m.Unlock()
+	m.removeOldestDatumLocked()
+}
+
+// removeOldestDatumLocked removes the LabelValue whose Datum has the oldest
+// timestamp.  The caller must hold m's lock.  It reports whether a datum was
+// removed (false only when the metric has no LabelValues left).
+func (m *Metric) removeOldestDatumLocked() bool {
 	var oldestLV *LabelValue
 	for _, lv := range m.LabelValues {
 		if oldestLV == nil || lv.Value.TimeUTC().Before(oldestLV.Value.TimeUTC()) {
 			oldestLV = lv
 		}
 	}
-	if oldestLV != nil {
-		glog.V(1).Infof("removeOldest: removing oldest LV: %v", oldestLV)
-		err := m.RemoveDatum(oldestLV.Labels...)
-		if err != nil {
-			glog.Warning(err)
-		}
+	if oldestLV == nil {
+		return false
 	}
+	glog.V(1).Infof("removeOldest: removing oldest LV: %v", oldestLV)
+	m.removeDatumLocked(oldestLV.Labels...)
+	return true
 }
 
 // RemoveDatum removes the Datum described by labelvalues from the Metric m.
@@ -204,20 +225,26 @@ func (m *Metric) RemoveDatum(labelvalues ...string) error {
 	}
 	m.Lock()
 	defer m.Unlock()
+	m.removeDatumLocked(labelvalues...)
+	return nil
+}
+
+// removeDatumLocked removes the LabelValue keyed by labelvalues.  The caller
+// must hold m's lock.
+func (m *Metric) removeDatumLocked(labelvalues ...string) {
 	k := buildLabelValueKey(labelvalues)
 	olv, ok := m.labelValuesMap[k]
-	if ok {
-		for i := 0; i < len(m.LabelValues); i++ {
-			lv := m.LabelValues[i]
-			if lv == olv {
-				// remove from the slice
-				m.LabelValues = append(m.LabelValues[:i], m.LabelValues[i+1:]...)
-				delete(m.labelValuesMap, k)
-				break
-			}
+	if !ok {
+		return
+	}
+	for i := 0; i < len(m.LabelValues); i++ {
+		if m.LabelValues[i] == olv {
+			// remove from the slice
+			m.LabelValues = append(m.LabelValues[:i], m.LabelValues[i+1:]...)
+			delete(m.labelValuesMap, k)
+			break
 		}
 	}
-	return nil
 }
 
 func (m *Metric) ExpireDatum(expiry time.Duration, labelvalues ...string) error {

--- a/internal/metrics/metric.go
+++ b/internal/metrics/metric.go
@@ -202,7 +202,9 @@ func (m *Metric) RemoveOldestDatum() {
 
 // removeOldestDatumLocked removes the LabelValue whose Datum has the oldest
 // timestamp.  The caller must hold m's lock.  It reports whether a datum was
-// removed (false only when the metric has no LabelValues left).
+// removed (false only when the metric has no LabelValues left).  Finding the
+// oldest is a linear scan over LabelValues, the same policy Store.Gc already
+// uses; on the GetDatum path it runs only on a cache miss while at the Limit.
 func (m *Metric) removeOldestDatumLocked() bool {
 	var oldestLV *LabelValue
 	for _, lv := range m.LabelValues {

--- a/internal/metrics/metric_test.go
+++ b/internal/metrics/metric_test.go
@@ -272,3 +272,64 @@ func TestMetricLabelValueRemovePastLimit(t *testing.T) {
 		t.Errorf("found label a which is unexpected: %#v", x)
 	}
 }
+
+func TestGetDatumEnforcesLimit(t *testing.T) {
+	m := NewMetric("test", "prog", Counter, Int, "foo")
+	m.Limit = 2
+
+	da, err := m.GetDatum("a")
+	testutil.FatalIfErr(t, err)
+	datum.SetInt(da, 1, time.Unix(1, 0))
+
+	db, err := m.GetDatum("b")
+	testutil.FatalIfErr(t, err)
+	datum.SetInt(db, 1, time.Unix(2, 0))
+
+	// A third distinct series exceeds Limit=2.  GetDatum must bound
+	// cardinality at creation time by evicting the oldest series ("a"),
+	// rather than deferring the cap to the next Store.Gc tick.
+	dc, err := m.GetDatum("c")
+	testutil.FatalIfErr(t, err)
+	datum.SetInt(dc, 1, time.Unix(3, 0))
+
+	if got := len(m.LabelValues); got != 2 {
+		t.Errorf("cardinality not bounded by Limit: got %d labelvalues, want 2: %#v", got, m.LabelValues)
+	}
+	if x := m.FindLabelValueOrNil([]string{"a"}); x != nil {
+		t.Errorf("oldest series \"a\" should have been evicted at the Limit, still present: %#v", x)
+	}
+	if x := m.FindLabelValueOrNil([]string{"c"}); x == nil {
+		t.Errorf("newest series \"c\" should be present")
+	}
+}
+
+// TestGetDatumUnlimitedByDefault guards the default: Limit == 0 means no cap.
+func TestGetDatumUnlimitedByDefault(t *testing.T) {
+	m := NewMetric("test", "prog", Counter, Int, "foo")
+	// Limit left at its zero value.
+	for i := 0; i < 100; i++ {
+		_, err := m.GetDatum(fmt.Sprintf("%d", i))
+		testutil.FatalIfErr(t, err)
+	}
+	if got := len(m.LabelValues); got != 100 {
+		t.Errorf("default Limit=0 should be unbounded: got %d labelvalues, want 100", got)
+	}
+}
+
+// BenchmarkGetDatumAtLimit measures the new-series (cache-miss) path while the
+// metric is already at its cardinality Limit, i.e. the eviction path.  The
+// steady-state cache-hit path is unaffected: the Limit check lives only on the
+// create branch.
+func BenchmarkGetDatumAtLimit(b *testing.B) {
+	m := NewMetric("test", "prog", Counter, Int, "foo")
+	m.Limit = 100
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d, err := m.GetDatum(fmt.Sprintf("%d", i))
+		if err != nil {
+			b.Fatal(err)
+		}
+		datum.SetInt(d, 1, time.Unix(int64(i), 0))
+	}
+}


### PR DESCRIPTION
Hi @jaqx0r — as greenlit in google/mtail#1006, here's the patch.

## Problem

`Metric.GetDatum` creates a new `LabelValue` on a label-set miss but never
consults `m.Limit` (it carried `// TODO Check m.Limit and expire old data`). The
cap is enforced only later, by `Store.Gc`, and only when `m.Limit > 0`. So
between GC ticks a program that labels a metric by a high-cardinality field
(request path, User-Agent, …) can grow label cardinality past its configured
`Limit` — bounded only by the GC interval, not by `Limit`. Same shape as the
high-cardinality behaviour in #1003 and the older #61.

## Fix

Enforce `Limit` at creation time in `GetDatum`, mirroring `Store.Gc`'s existing
**evict-oldest** policy (`RemoveOldestDatum`) so the two paths agree:

```go
if m.Limit > 0 {
    for len(m.LabelValues) >= m.Limit {
        if !m.removeOldestDatumLocked() {
            break
        }
    }
}
```

- **Default unchanged:** `Limit == 0` stays fully unbounded — no behavioural
  change unless an author opted into a cap.
- **Evict-oldest, not skip-create:** keeps `GetDatum`'s contract of always
  returning a usable datum, and matches what `Store.Gc` already does, so the
  in-line cap and the GC cap can't disagree.
- **Locking:** `GetDatum` already holds `m`'s lock, and `RemoveOldestDatum` →
  `RemoveDatum` take it again (non-reentrant → would deadlock). I factored out
  lock-free `removeOldestDatumLocked` / `removeDatumLocked` cores; the public
  `RemoveOldestDatum`/`RemoveDatum` keep their behaviour (and `RemoveOldestDatum`
  now holds the lock across its scan, closing a pre-existing unlocked read of
  `m.LabelValues`).
- **Hot path:** the steady-state cache-hit path is untouched — the `Limit` check
  lives only on the create (miss) branch.

## Tests / benchmark

- `TestGetDatumEnforcesLimit` — three series with `Limit = 2`; cardinality stays
  at 2 and the oldest is evicted at creation.
- `TestGetDatumUnlimitedByDefault` — `Limit == 0` admits 100 distinct series.
- `BenchmarkGetDatumAtLimit` — worst case (always-miss + always-evict at
  `Limit = 100`): ~2.1 µs/op, 8 allocs/op.
- Existing `TestMetricLabelValueRemovePastLimit` and the full `internal/metrics`
  suite pass unchanged.

Happy to adjust the policy (e.g. skip-create instead of evict-oldest) or add an
eviction counter if you'd prefer. Refs google/mtail#1006, #61.
