### PR TITLE
fix: Promote runtime errors to Error level.

### DIFF
--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -87,7 +87,7 @@ which accept a time duration string compatible with the Go
 ### Runtime error log rate
 
 If your programs deliberately fail to parse some log lines then you may end up
-generating lots of runtime errors which are normally logged at the standard INFO
+generating lots of runtime errors which are logged at the ERROR
 level, which can fill your disk.
 
 You can disable this with `--novm_logs_runtime_errors` or

--- a/internal/runtime/vm/vm.go
+++ b/internal/runtime/vm/vm.go
@@ -146,7 +146,7 @@ func (v *VM) errorf(format string, args ...interface{}) {
 		v.t.pc-1, i.Opcode, i.Operand, v.name, i.SourceLine+1)
 	v.runtimeError += fmt.Sprintf("Full input text from %q was %q", v.input.Filename, v.input.Line)
 	if v.logRuntimeErrors || bool(glog.V(1)) {
-		glog.Info(v.name + ": Runtime error: " + v.runtimeError)
+		glog.Error(v.name + ": Runtime error: " + v.runtimeError)
 
 		glog.Infof("Set logging verbosity higher (-v1 or more) to see full VM state dump.")
 	}


### PR DESCRIPTION
In `internal/runtime/vm/vm.go:149`, runtime errors were logged with `glog.Info()`. By default, glog only sends WARNING+ to stderr; INFO goes to log files (`/tmp/mtail.INFO`). Users watching stderr never see runtime errors unless they explicitly use `--logtostderr`.

- Runtime errors (division by zero, type mismatches, panics, etc.) are real errors that users need to see.
- `glog.Error` goes to stderr by default.
- The existing `v.logRuntimeErrors` guard still prevents logging when `--vm_logs_runtime_errors=false`.
- The verbose VM state dump (guarded by `glog.V(1)`) stays at INFO — those are debug details.
- The `ProgRuntimeErrors` counter and HTTP console (`/progz`) are unaffected.

Fixes: google/mtail#221